### PR TITLE
fix(orders-list): format time

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,23 @@
+# See https://help.github.com/articles/ignoring-files/ for more about ignoring files.
+
+# dependencies
+/node_modules
+/.pnp
+.pnp.js
+
+# testing
+/coverage
+
+# production
+/build
+
+# misc
+.DS_Store
+.env.local
+.env.development.local
+.env.test.local
+.env.production.local
+
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*

--- a/application/src/components/view-orders/ordersList.js
+++ b/application/src/components/view-orders/ordersList.js
@@ -8,6 +8,15 @@ const OrdersList = (props) => {
         </div>
     );
 
+    const formatDate = (hour, minute, second) => {
+        const hh = format24Hour(hour);
+        const mm = zeroPadDigit(minute);
+        const ss = zeroPadDigit(second);
+        return hh + ":" + mm + ":" + ss;
+    }
+    const zeroPadDigit = (n) => n > 9 ? n : `0${n}`;
+    const format24Hour = (n) => n > 12 ? zeroPadDigit(n - 12) : zeroPadDigit(n);
+
     return orders.map(order => {
         const createdDate = new Date(order.createdAt);
         return (
@@ -17,7 +26,7 @@ const OrdersList = (props) => {
                     <p>Ordered by: {order.ordered_by || ''}</p>
                 </div>
                 <div className="col-md-4 d-flex view-order-middle-col">
-                    <p>Order placed at {`${createdDate.getHours()}:${createdDate.getMinutes()}:${createdDate.getSeconds()}`}</p>
+                    <p>Order placed at {formatDate(createdDate.getHours(),createdDate.getMinutes(),createdDate.getSeconds())}</p>
                     <p>Quantity: {order.quantity}</p>
                 </div>
                 <div className="col-md-4 view-order-right-col">


### PR DESCRIPTION
## Changes
1. Adds ``, `` and `` methods to `orderList.js` component
2. Updates React's HTML to include `format24Hour` for each order's hour, minute and second as arguments.

## Purpose
Javascript's `Date` object returns single digit hour, minute and second without a `0` padding. 
- This could be confusing to a user as the time 09:01:09 would render as 21:1:9; a very confusing time format.

## Approach
This common front-end problem could be solved in three common ways....
 - 1: Adding a time conversation library like  `moment.js` to handle these use-cases.
 - 2: Build stand-alone re-usable react component to formate dates. Like, `dates.js` 
 - 3: ⭐️ Build a single`In-component` solution to handle only this specific case. 

I elected for the 3rd, and simplest solution for this use-case. Perhaps creating another issue to look deeper into this is needed. Or, could be added as a discussion point for a future meeting / topic. 
    
## Pre-Testing TODOs
- Run local environments 
  - Docker backend: `docker compose up`
  - Browser client: `npm start`
- Visit `localhost:3000` in your browser and login (NOTE: any email & password will be accepted)
- Select "Order Form" button in the navbar. 
- Make a couple menu selection where a minute, second or hour is represented with a singe digit.

## Testing Steps
- Select "View Order" and see your newly selected Item displayed. 
- Confirm that the dates are formatted correctly. 

## Learning
- With this issue, I'd probably reach out to the issue creator and see if  a 12-hour trimming would like to be included as well. 
  - Or, if it'd be a separate issue, discussion? 
- A discussion into time formatting within React I used: Convert YY:MM:DD Dates: https://www.geeksforgeeks.org/how-to-format-the-current-date-in-mm-dd-yyyy-hhmmss-format-using-node-js/

Closes [#2](https://github.com/Shift3/react-challenge-project-jan-2022/issues/2)
