### PR TITLE
fix(orderList): add zero-padding to timestamp

### DIFF
--- a/application/src/components/view-orders/ordersList.js
+++ b/application/src/components/view-orders/ordersList.js
@@ -17,7 +17,7 @@ const OrdersList = (props) => {
                     <p>Ordered by: {order.ordered_by || ''}</p>
                 </div>
                 <div className="col-md-4 d-flex view-order-middle-col">
-                    <p>Order placed at {`${createdDate.getHours()}:${createdDate.getMinutes()}:${createdDate.getSeconds()}`}</p>
+                    <p>Order placed at {`${createdDate.toLocaleTimeString('en-US', {hour12: false, hour: '2-digit', minute: '2-digit', second: '2-digit'})}`}</p>
                     <p>Quantity: {order.quantity}</p>
                 </div>
                 <div className="col-md-4 view-order-right-col">


### PR DESCRIPTION
## Changes
- Change order timestamp to zero pad the minutes and seconds

## Purpose
Allows users to view their order with the intended timestamp format

## Approach
This fix maintains the 24-hour time cycle while adding 0 padding to the minutes and seconds fields

## Pre-Testing TODOs
- Create an order when the current time minutes or seconds is less than 10.

## Testing Steps
1. Log in
2. Go to "View Orders" tab
3. Observe expected behavior

## Learning
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/toLocaleTimeString

Closes #2 
